### PR TITLE
Add mount() and umount() commands.

### DIFF
--- a/shlib/__init__.py
+++ b/shlib/__init__.py
@@ -10,7 +10,7 @@ from .shlib import (
     set_prefs,
 
     # filesystem utilities
-    cp, mv, rm, ln, touch, mkdir, cd, cwd, chmod, ls, lsd, lsf,
+    cp, mv, rm, ln, touch, mkdir, mount, umount, is_mounted, cd, cwd, chmod, ls, lsd, lsf,
 
     # path expansion utilities
     leaves, cartesian_product, brace_expand,

--- a/shlib/shlib.py
+++ b/shlib/shlib.py
@@ -236,6 +236,29 @@ def mkdir(*paths):
             if err.errno != errno.EEXIST or path.is_file():
                 raise
 
+# mount/umount {{{2
+class mount:
+
+    def __init__(self, path):
+        self.path = to_path(path)
+        self.mounted_externally = is_mounted(self.path)
+
+        if not self.mounted_externally:
+            Run(['mount', self.path])
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if not self.mounted_externally:
+            umount(self.path)
+
+def umount(path):
+    Run(['umount', path])
+
+def is_mounted(path):
+    return Run(['mountpoint', '-q', path], '0,1').status == 0
+
 # cd {{{2
 class cd:
     def __init__(self, path):


### PR DESCRIPTION
These commands are a little primitive, in that they don't expose any of the options available to the regular mount command.  But they are smart enough to not mount a drive that's already mounted, and can be used as a context manager.