### PR TITLE
Resolve #4 by changing the test

### DIFF
--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -244,7 +244,7 @@ def test_ls_contrast():
     touch(d1d2f2)
 
     # run test
-    paths = ls(d1, select="**")
+    paths = ls(d1, select="**", only="dir")
 
     # check
     assert set(str(f) for f in paths) == set(["d1", "d1/d1", "d1/d2"])


### PR DESCRIPTION
This version of the test behaves the same in both Python 3.12 and Python 3.13.

This change means allowing shlib to behave differently on Python 3.13+ compared to previous Python versions, matching the behavior of pathlib.

**I recommend merging either #5 or #6, _but not both_. Either one resolves the issue on its own.**

Fixes #4