### PR TITLE
Resolve #4 by changing the implementation

### DIFF
--- a/shlib/shlib.py
+++ b/shlib/shlib.py
@@ -382,6 +382,9 @@ def ls(*paths, **kwargs):
         return True
 
     select = to_str(select)
+    if select.endswith("**"):
+        # Add trailing slash to match only directories. See #4.
+        select += "/"
     retain_hidden = select.startswith(".") if hidden is None else hidden
     paths = paths if paths else ["."]
     for path in to_paths(paths):


### PR DESCRIPTION
This version preserves the previous behavior of matching only directories when given a trailing `**` glob, departing from the new behavior of pathlib.

**I recommend merging either #5 or #6, _but not both_. Either one resolves the issue on its own.**

Fixes #4